### PR TITLE
Fixes shebang lines for perl.

### DIFF
--- a/errinfo
+++ b/errinfo
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # errinfo - report on syscall failures and print errno error messages.
 #	    Written using Perl and DTrace (Solaris 10 03/05)

--- a/hotkernel
+++ b/hotkernel
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # hotkernel - sample on-CPU kernel-level functions and modules.
 #             Written using Perl and DTrace (Solaris 10 03/05)

--- a/hotuser
+++ b/hotuser
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # hotuser - sample on-CPU user-level functions and libraries.
 #           Written using Perl and DTrace (Solaris 10 03/05)


### PR DESCRIPTION
perl was hardcoded to a location where it no longer resides.
