### PR TITLE
Display correct PID if it is negative in kill.d

### DIFF
--- a/Proc/kill.d
+++ b/Proc/kill.d
@@ -47,7 +47,7 @@ dtrace:::BEGIN
 syscall::kill:entry
 {
 	/* Record target PID and signal */
-	self->target = arg0;
+	self->target = (pid_t)arg0;
 	self->signal = arg1;
 }
 


### PR DESCRIPTION
Current `kill.d` can't display negative PID, e.g:

```
FROM      COMMAND   SIG TO     RESULT
......
 2377         bash     1 4294964696 0
......
```

After my commit:

```
FROM      COMMAND   SIG TO     RESULT
......
 2780         bash     1 -2976  0
......
```